### PR TITLE
Open notes externally

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@ Alfred workflow for automating some actions when working with [Joplin](https://j
 
 **[Downloads](https://github.com/beet/joplin_alfred_actions/releases)**
 
+As humans, we think of our notes in terms of their headings/titles, but Joplin names the files with a kind of SHA like `2a1da8fb229c4824ab64833b589b108b`. This allows links between pages to remain intact even if their titles are changed, but makes the files themselves more difficult to work with.
+
+These actions provide an abstraction over the note IDs that allows you to stay in the mind-space of page headings while working with Joplin.
+
+## Setup
+
+### Notes location
+
+When first installing the Alfred workflow, it should prompt you to enter a value for the `base_directory` variable.
+
+This should be set to the _relative_ path, without your home directory included.
+
+For example, if your Joplin notes are in `/Users/homedir/Library/Mobile Documents/com~apple~CloudDocs/Docs/Joplin/`, you should set `base_directory` to `/Library/Mobile Documents/com~apple~CloudDocs/Docs/Joplin`
+
 ## Insert wiki link
 
 Keyword: `jwl`
@@ -11,15 +25,37 @@ Keyword: `jwl`
 Insert a wiki link to any Joplin page with fuzzy search of the page headings that looks like:
 
 ```
-[Index](:/2a1da8fb229c4824ab64833b589b108b)
+[Page heading](:/2a1da8fb229c4824ab64833b589b108b)
 ```
 
-It's very common in wiki-like apps to be able to create a new page by inserting a link into another page and then clicking it, but most other wiki-like apps follow the convention of using a format like `[[Page Name]]` for the links.
+Much easier than showing the notes list, finding the target note, right clicking on it, selecting "Copy Markdown link", then pasting it into the page.
 
-Joplin follows the convention of using some kind of SHA for the filename, like `2a1da8fb229c4824ab64833b589b108b` which is generated when pages have been created.
+## Open in Marked 2
 
-So while the workflow isn't quite as neat, you can still just create a new page with `COMMAND+N`, use `COMMANG+G` to navigate back to the target page, then use this workflow to insert a link back to the new page.
+Keyword: `jmk`
 
-Yes, you can right click on the file, if you have the note list exposed, and copy its markdown link from there. If you have the list sorted with the newest notes at the top, it will be easy to find too.
+Opens the selected note in [Marked 2](https://marked2app.com).
 
-I often find myself interlinking exsiting pages though during review and reflection, and this workflow means I can stay in the flow and link them up by name instead of having to locate them in the notes list, copy the markdown link, then paste it into page I'm working on.
+Joplin's live preview is great, but sometimes it's handy to have a rendered preview of one page open for reference while working on another in Joplin.
+
+This action does not require the targe note being open in Joplin, in fact, it doesn't even require Joplin itself being open at all.
+
+## Reveal in Finder
+
+Keyword: `jrf`
+
+Reveals the selected note in Finder.
+
+As humans, we think of our notes in terms of their headings, but Joplin names the files with some kind of SHA like `2a1da8fb229c4824ab64833b589b108b`, so if you need to locate a specific note in Finder for something, this action makes it easy with fuzzy search by heading.
+
+## Browse in Alfred
+
+Keyword: `jba`
+
+Kinda renders the reveal in Finder action redundant, as Alfred has a reveal in Finder action itself, but this action also provides access to Alfred's other file actions, including "Open with" if you want to use a different editor, like Folding Text for example.
+
+Usage:
+
+* Bring up Alfred and enter `jba` 
+* Search for the desired note, and hit enter after selecting it
+* Press the right arrow on the keyboard to bring up Alfred's file actions

--- a/info.plist
+++ b/info.plist
@@ -8,11 +8,50 @@
 	<string>Productivity</string>
 	<key>connections</key>
 	<dict>
+		<key>48148733-F1FB-43B4-BA8C-13D0E53B8218</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>F6EBA913-91EB-494F-A242-14D16271C547</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>7EAF6C64-1E5D-43DF-9705-42AE080BE8F7</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>A4119268-FBD7-4F55-8EA8-4CAF95E2B8F4</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
 		<key>BD9E31D7-F171-4174-B726-A44C2DAE83EC</key>
 		<array>
 			<dict>
 				<key>destinationuid</key>
 				<string>793F4654-386B-4CE2-B264-E21D3CF2C657</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>F52D1640-2185-41FD-8D23-5797557211EE</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>4181BF5B-700B-4D7E-BC1C-D34DDAC64CB6</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -101,6 +140,203 @@ print Joplin::WikiLinks.new.json</string>
 			<key>version</key>
 			<integer>3</integer>
 		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>openwith</key>
+				<string>/Applications/Marked 2.app</string>
+				<key>sourcefile</key>
+				<string></string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.openfile</string>
+			<key>uid</key>
+			<string>A4119268-FBD7-4F55-8EA8-4CAF95E2B8F4</string>
+			<key>version</key>
+			<integer>3</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>alfredfiltersresults</key>
+				<true/>
+				<key>alfredfiltersresultsmatchmode</key>
+				<integer>2</integer>
+				<key>argumenttreatemptyqueryasnil</key>
+				<false/>
+				<key>argumenttrimmode</key>
+				<integer>0</integer>
+				<key>argumenttype</key>
+				<integer>0</integer>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>keyword</key>
+				<string>jmk</string>
+				<key>queuedelaycustom</key>
+				<integer>3</integer>
+				<key>queuedelayimmediatelyinitially</key>
+				<true/>
+				<key>queuedelaymode</key>
+				<integer>0</integer>
+				<key>queuemode</key>
+				<integer>1</integer>
+				<key>runningsubtext</key>
+				<string></string>
+				<key>script</key>
+				<string>require "./lib/alfred"
+require "./lib/joplin"
+
+print Joplin::NotesList.new.json</string>
+				<key>scriptargtype</key>
+				<integer>1</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>subtext</key>
+				<string></string>
+				<key>title</key>
+				<string>Open Joplin page in Marked</string>
+				<key>type</key>
+				<integer>2</integer>
+				<key>withspace</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.input.scriptfilter</string>
+			<key>uid</key>
+			<string>7EAF6C64-1E5D-43DF-9705-42AE080BE8F7</string>
+			<key>version</key>
+			<integer>3</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>path</key>
+				<string></string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.revealfile</string>
+			<key>uid</key>
+			<string>F6EBA913-91EB-494F-A242-14D16271C547</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>alfredfiltersresults</key>
+				<true/>
+				<key>alfredfiltersresultsmatchmode</key>
+				<integer>2</integer>
+				<key>argumenttreatemptyqueryasnil</key>
+				<false/>
+				<key>argumenttrimmode</key>
+				<integer>0</integer>
+				<key>argumenttype</key>
+				<integer>0</integer>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>keyword</key>
+				<string>jrf</string>
+				<key>queuedelaycustom</key>
+				<integer>3</integer>
+				<key>queuedelayimmediatelyinitially</key>
+				<true/>
+				<key>queuedelaymode</key>
+				<integer>0</integer>
+				<key>queuemode</key>
+				<integer>1</integer>
+				<key>runningsubtext</key>
+				<string></string>
+				<key>script</key>
+				<string>require "./lib/alfred"
+require "./lib/joplin"
+
+print Joplin::NotesList.new.json</string>
+				<key>scriptargtype</key>
+				<integer>1</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>subtext</key>
+				<string></string>
+				<key>title</key>
+				<string>Reveal Joplin page in Finder</string>
+				<key>type</key>
+				<integer>2</integer>
+				<key>withspace</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.input.scriptfilter</string>
+			<key>uid</key>
+			<string>48148733-F1FB-43B4-BA8C-13D0E53B8218</string>
+			<key>version</key>
+			<integer>3</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>path</key>
+				<string></string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.browseinalfred</string>
+			<key>uid</key>
+			<string>4181BF5B-700B-4D7E-BC1C-D34DDAC64CB6</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>alfredfiltersresults</key>
+				<true/>
+				<key>alfredfiltersresultsmatchmode</key>
+				<integer>2</integer>
+				<key>argumenttreatemptyqueryasnil</key>
+				<false/>
+				<key>argumenttrimmode</key>
+				<integer>0</integer>
+				<key>argumenttype</key>
+				<integer>0</integer>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>keyword</key>
+				<string>jba</string>
+				<key>queuedelaycustom</key>
+				<integer>3</integer>
+				<key>queuedelayimmediatelyinitially</key>
+				<true/>
+				<key>queuedelaymode</key>
+				<integer>0</integer>
+				<key>queuemode</key>
+				<integer>1</integer>
+				<key>runningsubtext</key>
+				<string></string>
+				<key>script</key>
+				<string>require "./lib/alfred"
+require "./lib/joplin"
+
+print Joplin::NotesList.new.json</string>
+				<key>scriptargtype</key>
+				<integer>1</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>subtext</key>
+				<string></string>
+				<key>title</key>
+				<string>Browse Joplin page in Alfred</string>
+				<key>type</key>
+				<integer>2</integer>
+				<key>withspace</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.input.scriptfilter</string>
+			<key>uid</key>
+			<string>F52D1640-2185-41FD-8D23-5797557211EE</string>
+			<key>version</key>
+			<integer>3</integer>
+		</dict>
 	</array>
 	<key>readme</key>
 	<string>Handy extensions for interaction with Joplin through Alfred.
@@ -108,12 +344,44 @@ print Joplin::WikiLinks.new.json</string>
 See https://github.com/beet/joplin_alfred_actions for a deatailed readme.</string>
 	<key>uidata</key>
 	<dict>
+		<key>4181BF5B-700B-4D7E-BC1C-D34DDAC64CB6</key>
+		<dict>
+			<key>xpos</key>
+			<integer>235</integer>
+			<key>ypos</key>
+			<integer>585</integer>
+		</dict>
+		<key>48148733-F1FB-43B4-BA8C-13D0E53B8218</key>
+		<dict>
+			<key>note</key>
+			<string>Reveal selected note in Finder</string>
+			<key>xpos</key>
+			<integer>40</integer>
+			<key>ypos</key>
+			<integer>405</integer>
+		</dict>
 		<key>793F4654-386B-4CE2-B264-E21D3CF2C657</key>
 		<dict>
 			<key>xpos</key>
-			<integer>270</integer>
+			<integer>220</integer>
 			<key>ypos</key>
+			<integer>45</integer>
+		</dict>
+		<key>7EAF6C64-1E5D-43DF-9705-42AE080BE8F7</key>
+		<dict>
+			<key>note</key>
+			<string>Open selected note in Marked 2</string>
+			<key>xpos</key>
 			<integer>40</integer>
+			<key>ypos</key>
+			<integer>225</integer>
+		</dict>
+		<key>A4119268-FBD7-4F55-8EA8-4CAF95E2B8F4</key>
+		<dict>
+			<key>xpos</key>
+			<integer>225</integer>
+			<key>ypos</key>
+			<integer>225</integer>
 		</dict>
 		<key>BD9E31D7-F171-4174-B726-A44C2DAE83EC</key>
 		<dict>
@@ -122,7 +390,23 @@ See https://github.com/beet/joplin_alfred_actions for a deatailed readme.</strin
 			<key>xpos</key>
 			<integer>40</integer>
 			<key>ypos</key>
+			<integer>45</integer>
+		</dict>
+		<key>F52D1640-2185-41FD-8D23-5797557211EE</key>
+		<dict>
+			<key>note</key>
+			<string>Browse selected note in Alfred</string>
+			<key>xpos</key>
 			<integer>40</integer>
+			<key>ypos</key>
+			<integer>585</integer>
+		</dict>
+		<key>F6EBA913-91EB-494F-A242-14D16271C547</key>
+		<dict>
+			<key>xpos</key>
+			<integer>230</integer>
+			<key>ypos</key>
+			<integer>405</integer>
 		</dict>
 	</dict>
 	<key>variables</key>

--- a/lib/joplin/note_file.rb
+++ b/lib/joplin/note_file.rb
@@ -28,6 +28,10 @@ module Joplin
       @contents ||= File.read(filename)
     end
 
+    def is_note?
+      !is_metadata? && !is_attachment?
+    end
+
     def is_metadata?
       content_lines.first.match?(/^id:\s/)
     end

--- a/lib/joplin/notes_list.rb
+++ b/lib/joplin/notes_list.rb
@@ -1,0 +1,27 @@
+=begin
+
+Produces JSON for the Alfred script filter input to search all headings
+contained in all Joplin files:
+
+    print Joplin::NotesList.new.json
+
+Takes the first top-level heading found in each note.
+
+=end
+module Joplin
+  class NotesList < Base
+    def alfred_items
+      [].tap do |array|
+        for_each_note do |note_file|
+          next unless note_file.is_note?
+
+          array << Alfred::Item.new(
+            note_file.heading,
+            subtitle: note_file.basename,
+            arg: note_file.filename
+          )
+        end
+      end.uniq.sort_by(&:title)
+    end
+  end
+end

--- a/lib/joplin/wiki_links.rb
+++ b/lib/joplin/wiki_links.rb
@@ -13,9 +13,7 @@ module Joplin
     def alfred_items
       [].tap do |array|
         for_each_note do |note_file|
-          # Might get to a factory interface one day, but in the meantime
-          # maybe .is_note? should encpsulate this?
-          next if note_file.is_metadata? || note_file.is_attachment?
+          next unless note_file.is_note?
 
           array << Alfred::Item.new(
             note_file.heading,

--- a/lib/spec/joplin/note_file_spec.rb
+++ b/lib/spec/joplin/note_file_spec.rb
@@ -61,6 +61,38 @@ RSpec.describe Joplin::NoteFile do
     end
   end
 
+  context "#is_note?" do
+    before do
+      allow(note_file).to receive(:is_metadata?).and_return(is_metadata)
+      allow(note_file).to receive(:is_attachment?).and_return(is_attachment)
+    end
+
+    let(:is_metadata) { false }
+    let(:is_attachment) { false }
+
+    context "when the note file is metadata" do
+      let(:is_metadata) { true }
+
+      it 'is false' do
+        expect(note_file).to_not be_is_note
+      end
+    end
+
+    context "when the note file is an attachment" do
+      let(:is_attachment) { true }
+
+      it 'is false' do
+        expect(note_file).to_not be_is_note
+      end
+    end
+
+    context "when the note file is not metadata or an attachment" do
+      it 'is true' do
+        expect(note_file).to be_is_note
+      end
+    end
+  end
+
   context "#heading" do
     let(:file_contents) { double("file_contents") }
     let(:heading_component) { double(Joplin::NoteComponents::Heading, contents: heading_contents) }

--- a/lib/spec/joplin/notes_list_spec.rb
+++ b/lib/spec/joplin/notes_list_spec.rb
@@ -1,0 +1,80 @@
+require "spec_helper"
+
+RSpec.describe Joplin::NotesList do
+  subject(:wiki_links) { Joplin::NotesList.new }
+
+  context "#alfred_items" do
+    let(:note_file_1) {
+      double(
+        Joplin::NoteFile,
+        heading: heading_1,
+        basename: basename_1,
+        filename: filename_1,
+        is_note?: true
+      )
+    }
+    let(:heading_1) { double("heading_1") }
+    let(:basename_1) { double("basename_1") }
+    let(:filename_1) { double("filename_1") }
+
+    let(:note_file_2) {
+      double(
+        Joplin::NoteFile,
+        heading: heading_2,
+        basename: basename_2,
+        filename: filename_2,
+        is_note?: true
+      )
+    }
+    let(:heading_2) { double("heading_2") }
+    let(:basename_2) { double("basename_2") }
+    let(:filename_2) { double("filename_2") }
+
+    let(:note_file_3) {
+      double(
+        Joplin::NoteFile,
+        heading: heading_3,
+        basename: basename_3,
+        filename: filename_3,
+        is_note?: false
+      )
+    }
+    let(:heading_3) { double("heading_3") }
+    let(:basename_3) { double("basename_3") }
+    let(:filename_3) { double("filename_3") }
+
+    let(:alfred_item_1) { double(Alfred::Item, title: title_1) }
+    let(:title_1) { "title_B" }
+
+    let(:alfred_item_2) { double(Alfred::Item, title: title_2) }
+    let(:title_2) { "title_A" }
+
+    before do
+      allow(Alfred::Item).to receive(:new)
+        .with(
+          heading_1,
+          subtitle: basename_1,
+          arg: filename_1
+        )
+        .and_return(alfred_item_1)
+
+      allow(Alfred::Item).to receive(:new)
+        .with(
+          heading_2,
+          subtitle: basename_2,
+          arg: filename_2
+        )
+        .and_return(alfred_item_2)
+
+      allow(wiki_links).to(
+        receive(:for_each_note)
+          .and_yield(note_file_1)
+          .and_yield(note_file_2)
+          .and_yield(note_file_3))
+    end
+
+    it "sorts a collection of Alfred::Item objects for each file note that is not metadata or an attachment" do
+      expect(wiki_links.alfred_items).to eq([alfred_item_2, alfred_item_1])
+    end
+  end
+end

--- a/lib/spec/joplin/wiki_links_spec.rb
+++ b/lib/spec/joplin/wiki_links_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe Joplin::WikiLinks do
         heading: heading_1,
         basename: basename_1,
         markdown_link: markdown_link_1,
-        is_metadata?: false,
-        is_attachment?: false,
+        is_note?: true
       )
     }
     let(:heading_1) { double("heading_1") }
@@ -24,8 +23,7 @@ RSpec.describe Joplin::WikiLinks do
         heading: heading_2,
         basename: basename_2,
         markdown_link: markdown_link_2,
-        is_metadata?: false,
-        is_attachment?: false,
+        is_note?: true
       )
     }
     let(:heading_2) { double("heading_2") }
@@ -38,27 +36,12 @@ RSpec.describe Joplin::WikiLinks do
         heading: heading_3,
         basename: basename_3,
         markdown_link: markdown_link_3,
-        is_metadata?: true,
-        is_attachment?: false,
+        is_note?: false
       )
     }
     let(:heading_3) { double("heading_3") }
     let(:basename_3) { double("basename_3") }
     let(:markdown_link_3) { double("markdown_link_3") }
-
-    let(:note_file_4) {
-      double(
-        Joplin::NoteFile,
-        heading: heading_4,
-        basename: basename_4,
-        markdown_link: markdown_link_4,
-        is_metadata?: true,
-        is_attachment?: false,
-      )
-    }
-    let(:heading_4) { double("heading_4") }
-    let(:basename_4) { double("basename_4") }
-    let(:markdown_link_4) { double("markdown_link_4") }
 
     let(:alfred_item_1) { double(Alfred::Item, title: title_1) }
     let(:title_1) { "title_B" }
@@ -87,8 +70,7 @@ RSpec.describe Joplin::WikiLinks do
         receive(:for_each_note)
           .and_yield(note_file_1)
           .and_yield(note_file_2)
-          .and_yield(note_file_3)
-          .and_yield(note_file_4))
+          .and_yield(note_file_3))
     end
 
     it "sorts a collection of Alfred::Item objects for each file note that is not metadata or an attachment" do


### PR DESCRIPTION
Adds Alfred actions for opening Joplin notes in Marked 2, revealing them in Finder, and browsing them Alfred.