### PR TITLE
Feature: table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,15 @@ Usage:
 * Bring up Alfred and enter `jba` 
 * Search for the desired note, and hit enter after selecting it
 * Press the right arrow on the keyboard to bring up Alfred's file actions
+
+## Table Of Contents
+
+Keyword: `jtoc`
+
+Select a Joplin note with fuzzy search by title, and it will generate a nested table of contents of other notes that it links to, and their child notes etc. recursively up to 5 levels deep. The output is a Markdown nested bullet list of links to the child pages, which is copied to the system clipboard.
+
+You can then paste that into another page, but pasting it into the same page will mean that regenerating the TOC for that same page will result in every nested child page being seen as a direct decendent of the parent page, as it now contains a link directly to each one, so you'd want to remove it first.
+
+It excludes recursive links back from a child page to its parent, and will stop at 5 levels deep. If it takes more than 5 seconds to process, it will timeout and return an error.
+
+**NOTE:** you may need to explicitly invoke Joplin's file sync so that the workflow picks up any notes that have been created/edited recently.

--- a/info.plist
+++ b/info.plist
@@ -34,11 +34,47 @@
 				<false/>
 			</dict>
 		</array>
+		<key>B436058D-472E-483F-8EB0-43208771DE1C</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>ED178F56-C39E-4CD9-94D0-587E766621CE</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
 		<key>BD9E31D7-F171-4174-B726-A44C2DAE83EC</key>
 		<array>
 			<dict>
 				<key>destinationuid</key>
 				<string>793F4654-386B-4CE2-B264-E21D3CF2C657</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>ED178F56-C39E-4CD9-94D0-587E766621CE</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>C5C27B06-C97E-4B7F-9DBA-E44D63911DD5</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>241E2FE4-4D32-4609-8A3B-9D6D0BB6B082</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -71,6 +107,58 @@
 	<string>Jopliin Actions</string>
 	<key>objects</key>
 	<array>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>alfredfiltersresults</key>
+				<true/>
+				<key>alfredfiltersresultsmatchmode</key>
+				<integer>0</integer>
+				<key>argumenttreatemptyqueryasnil</key>
+				<true/>
+				<key>argumenttrimmode</key>
+				<integer>0</integer>
+				<key>argumenttype</key>
+				<integer>0</integer>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>keyword</key>
+				<string>jtoc</string>
+				<key>queuedelaycustom</key>
+				<integer>3</integer>
+				<key>queuedelayimmediatelyinitially</key>
+				<true/>
+				<key>queuedelaymode</key>
+				<integer>0</integer>
+				<key>queuemode</key>
+				<integer>1</integer>
+				<key>runningsubtext</key>
+				<string></string>
+				<key>script</key>
+				<string>require "./lib/alfred"
+require "./lib/joplin"
+
+print Joplin::NotesList.new.json</string>
+				<key>scriptargtype</key>
+				<integer>1</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>subtext</key>
+				<string></string>
+				<key>title</key>
+				<string>Generate a table of contents</string>
+				<key>type</key>
+				<integer>2</integer>
+				<key>withspace</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.input.scriptfilter</string>
+			<key>uid</key>
+			<string>B436058D-472E-483F-8EB0-43208771DE1C</string>
+			<key>version</key>
+			<integer>3</integer>
+		</dict>
 		<dict>
 			<key>config</key>
 			<dict>
@@ -126,6 +214,53 @@ print Joplin::WikiLinks.new.json</string>
 		<dict>
 			<key>config</key>
 			<dict>
+				<key>lastpathcomponent</key>
+				<false/>
+				<key>onlyshowifquerypopulated</key>
+				<false/>
+				<key>removeextension</key>
+				<false/>
+				<key>text</key>
+				<string></string>
+				<key>title</key>
+				<string>TOC copied to clipboard</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.output.notification</string>
+			<key>uid</key>
+			<string>C5C27B06-C97E-4B7F-9DBA-E44D63911DD5</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>concurrently</key>
+				<false/>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>script</key>
+				<string>require "./lib/alfred"
+require "./lib/joplin"
+
+print Joplin::TableOfContents.process(ARGV[0])</string>
+				<key>scriptargtype</key>
+				<integer>1</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>type</key>
+				<integer>2</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.script</string>
+			<key>uid</key>
+			<string>ED178F56-C39E-4CD9-94D0-587E766621CE</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
 				<key>autopaste</key>
 				<true/>
 				<key>clipboardtext</key>
@@ -137,6 +272,23 @@ print Joplin::WikiLinks.new.json</string>
 			<string>alfred.workflow.output.clipboard</string>
 			<key>uid</key>
 			<string>793F4654-386B-4CE2-B264-E21D3CF2C657</string>
+			<key>version</key>
+			<integer>3</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>autopaste</key>
+				<false/>
+				<key>clipboardtext</key>
+				<string>{query}</string>
+				<key>transient</key>
+				<false/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.output.clipboard</string>
+			<key>uid</key>
+			<string>241E2FE4-4D32-4609-8A3B-9D6D0BB6B082</string>
 			<key>version</key>
 			<integer>3</integer>
 		</dict>
@@ -344,6 +496,13 @@ print Joplin::NotesList.new.json</string>
 See https://github.com/beet/joplin_alfred_actions for a deatailed readme.</string>
 	<key>uidata</key>
 	<dict>
+		<key>241E2FE4-4D32-4609-8A3B-9D6D0BB6B082</key>
+		<dict>
+			<key>xpos</key>
+			<integer>870</integer>
+			<key>ypos</key>
+			<integer>160</integer>
+		</dict>
 		<key>4181BF5B-700B-4D7E-BC1C-D34DDAC64CB6</key>
 		<dict>
 			<key>xpos</key>
@@ -383,12 +542,33 @@ See https://github.com/beet/joplin_alfred_actions for a deatailed readme.</strin
 			<key>ypos</key>
 			<integer>225</integer>
 		</dict>
+		<key>B436058D-472E-483F-8EB0-43208771DE1C</key>
+		<dict>
+			<key>xpos</key>
+			<integer>440</integer>
+			<key>ypos</key>
+			<integer>45</integer>
+		</dict>
 		<key>BD9E31D7-F171-4174-B726-A44C2DAE83EC</key>
 		<dict>
 			<key>note</key>
 			<string>Insert a wiki link to any text note with fuzzy search by heading</string>
 			<key>xpos</key>
 			<integer>40</integer>
+			<key>ypos</key>
+			<integer>45</integer>
+		</dict>
+		<key>C5C27B06-C97E-4B7F-9DBA-E44D63911DD5</key>
+		<dict>
+			<key>xpos</key>
+			<integer>865</integer>
+			<key>ypos</key>
+			<integer>45</integer>
+		</dict>
+		<key>ED178F56-C39E-4CD9-94D0-587E766621CE</key>
+		<dict>
+			<key>xpos</key>
+			<integer>640</integer>
 			<key>ypos</key>
 			<integer>45</integer>
 		</dict>

--- a/lib/joplin/base.rb
+++ b/lib/joplin/base.rb
@@ -11,6 +11,8 @@ note files and yields a Joplin::NoteFile instance.
 =end
 module Joplin
   class Base
+    EXT_NAME = ".md"
+
     attr_reader :alfred_script_filter
 
     def initialize
@@ -32,7 +34,7 @@ module Joplin
     end
 
     def notes_directory
-      "#{base_directory}/*.md"
+      "#{base_directory}/*#{EXT_NAME}"
     end
 
     def base_directory

--- a/lib/joplin/note_components/note_links.rb
+++ b/lib/joplin/note_components/note_links.rb
@@ -1,0 +1,36 @@
+=begin
+
+This component returns a collection of Joplin::NoteFile objects for all notes
+that a note file has outbound links to:
+
+    Joplin::NoteComponents::NoteLinks.new(contents).child_notes
+    =>  [<#Jolin::NoteFile>, <#Jolin::NoteFile>, <#Jolin::NoteFile>]
+
+=end
+module Joplin
+  module NoteComponents
+    class NoteLinks < Base
+      def child_notes
+        ids.map do |id|
+          Joplin::TableOfContents.find_note(id)
+        end.compact.sort
+      end
+
+      private
+
+      # Map the links like "[text](:/119ddf766b7142f1bd1342e7bde12d82)" to a
+      # collection of ID strings like ["119ddf766b7142f1bd1342e7bde12d82"]
+      def ids
+        links.map do |link|
+          link.match(/\[[^\]]+\]\(:\/([^)]+)\)/)[1]
+        end.uniq
+      end
+
+      # Links to nother Joplin notes look like
+      # [text](:/119ddf766b7142f1bd1342e7bde12d82)
+      def links
+        note_contents.scan(/\[[^\]]+\]\(:\/[^)]+\)/)
+      end
+    end
+  end
+end

--- a/lib/joplin/note_file.rb
+++ b/lib/joplin/note_file.rb
@@ -16,7 +16,7 @@ PORO to encapsulate a note file:
 =end
 module Joplin
   class NoteFile
-    EXT_NAME = ".md"
+    include Comparable
 
     attr_reader :filename
 
@@ -60,6 +60,14 @@ module Joplin
 
     def basename
       File.basename(filename)
+    end
+
+    def <=>(other_note)
+      heading <=> other_note.heading
+    end
+
+    def ==(other_note)
+      id == other_note.id
     end
 
     private

--- a/lib/joplin/note_file.rb
+++ b/lib/joplin/note_file.rb
@@ -29,7 +29,7 @@ module Joplin
     end
 
     def is_note?
-      !is_metadata? && !is_attachment?
+      !is_metadata? && !is_attachment?  && has_heading?
     end
 
     def is_metadata?

--- a/lib/joplin/note_file.rb
+++ b/lib/joplin/note_file.rb
@@ -46,6 +46,10 @@ module Joplin
       "[#{heading}](:/#{id})"
     end
 
+    def has_heading?
+      heading != ""
+    end
+
     def heading
       NoteComponents::Heading.new(contents).contents
     end

--- a/lib/joplin/note_file.rb
+++ b/lib/joplin/note_file.rb
@@ -62,6 +62,11 @@ module Joplin
       File.basename(filename)
     end
 
+    # All notes that this note links to
+    def child_notes
+      @child_notes ||= NoteComponents::NoteLinks.new(contents).child_notes
+    end
+
     def <=>(other_note)
       heading <=> other_note.heading
     end

--- a/lib/joplin/note_file.rb
+++ b/lib/joplin/note_file.rb
@@ -51,7 +51,7 @@ module Joplin
     end
 
     def id
-      basename.gsub(EXT_NAME, "")
+      basename.gsub(Joplin::Base::EXT_NAME, "")
     end
 
     def basename

--- a/lib/joplin/table_of_contents.rb
+++ b/lib/joplin/table_of_contents.rb
@@ -1,0 +1,42 @@
+=begin
+
+Abstraction layer for interacting with Joplin's notes through a table of
+contents:
+
+Fetch a Joplin::NoteFile instance for the given note ID. Will always return
+the same instance, so if two different note files contain links to the same
+file, .find_note() will return the same object.
+
+    Joplin::TableOfContents.find_note("051c175223fc4987bbc8b2bb22356037")
+    => <#Joplin::NoteFile>
+
+=end
+module Joplin
+  module TableOfContents
+    require 'timeout'
+
+    TIMEOUT_SECONDS = 5
+
+    class << self
+      def find_note(id)
+        note_files.detect do |note_file|
+          note_file.id == id
+        end
+      end
+
+      private
+
+      def note_files
+        @note_files ||= [].tap do |array|
+          Dir.glob("#{ENV["HOME"]}#{Alfred::Settings.base_directory}/*#{Joplin::Base::EXT_NAME}") do |filename|
+            note_file = Joplin::NoteFile.new(filename)
+
+            array << note_file if note_file.is_note?
+          end
+
+          array.uniq!
+        end
+      end
+    end
+  end
+end

--- a/lib/joplin/table_of_contents/toc_processor.rb
+++ b/lib/joplin/table_of_contents/toc_processor.rb
@@ -1,0 +1,74 @@
+=begin
+
+Service for recursively processing the child notes of a given note file and
+generating a nested table of contents in Markdown bullet list format:
+
+    Joplin::TocProcessor::TocProcessor.new(note_file).process
+
+As it recursively processes its child notes, it will pass in the nesting
+level, TOC string, and branch array.
+
+The NESTING_LIMIT constant defines how many levels deep it will go, which
+could be abstracted out to Alfred::Settings
+
+=end
+module Joplin
+  module TableOfContents
+    class TocProcessor
+      attr_reader :note_file, :level, :toc, :branch
+
+      NESTING_LIMIT = 5
+
+      def initialize(note_file, level: nil, toc: nil, branch: nil)
+        @note_file = note_file
+        @level = level || 0
+        @toc = toc || ""
+        @branch = branch.dup || []
+      end
+
+      def process
+        toc << note_file_link(note_file, indentation)
+
+        branch << note_file
+
+        process_child_notes
+
+        toc
+      end
+
+      private
+
+      def note_file_link(note_file, indentation)
+        "#{indentation}* #{note_file.markdown_link}\n"
+      end
+
+      def indentation
+        "  " * level
+      end
+
+      def process_child_notes
+        return if child_notes.none?
+
+        if level > NESTING_LIMIT
+          toc << "#{indentation}  * _Skipped #{child_notes.size} child notes_\n"
+
+          return
+        end
+
+        # Add all of this note's child notes to the branch before processing
+        # them for scenarios where the child notes have links to each other,
+        # which just clutters up the TOC and creates duplicate nested
+        # branches
+        branch.concat(child_notes)
+
+        child_notes.each do |child_note|
+          TocProcessor.new(child_note, level: level + 1, toc: toc, branch: branch).process
+        end
+      end
+
+      def child_notes
+        @child_notes ||= note_file.child_notes - branch
+      end
+    end
+  end
+end

--- a/lib/spec/joplin/base_spec.rb
+++ b/lib/spec/joplin/base_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Joplin::Base do
   end
 
   context "text note iteration" do
-    let(:notes_directory) { "#{ENV["HOME"]}#{base_directory}/*.md" }
+    let(:notes_directory) { "#{ENV["HOME"]}#{base_directory}/*#{Joplin::Base::EXT_NAME}" }
     let(:note_file) { double(Joplin::NoteFile, filename: filename) }
     let(:filename) { "filename" }
 

--- a/lib/spec/joplin/note_components/note_links_spec.rb
+++ b/lib/spec/joplin/note_components/note_links_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe Joplin::NoteComponents::NoteLinks do
+  let(:contents) { %(
+    # Heading
+
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+    * [#{heading_1}](:/#{id_1})
+    * [#{heading_2}](:/#{id_2})
+    * [#{heading_3}](:/#{id_3})
+  ) }
+  let(:id_1) { "68452624633787105385534405760771" }
+  let(:id_2) { "26124086375045357804537730673805" }
+  let(:id_3) { "52236057733770220525440233834384" }
+  let(:heading_1) { "Heading 3" }
+  let(:heading_2) { "Heading 2" }
+  let(:heading_3) { "Heading 1" }
+  let(:note_1) { Joplin::NoteFile.new(filename = "") }
+  let(:note_2) { Joplin::NoteFile.new(filename = "") }
+  let(:note_3) { Joplin::NoteFile.new(filename = "") }
+
+  subject(:note_links) { Joplin::NoteComponents::NoteLinks.new(contents) }
+
+  before do
+    allow(Joplin::TableOfContents).to receive(:find_note).with(id_1).and_return(note_1)
+    allow(Joplin::TableOfContents).to receive(:find_note).with(id_2).and_return(note_2)
+    allow(Joplin::TableOfContents).to receive(:find_note).with(id_3).and_return(note_3)
+
+    allow(note_1).to receive(:id).and_return(id_1)
+    allow(note_2).to receive(:id).and_return(id_2)
+    allow(note_3).to receive(:id).and_return(id_3)
+
+    allow(note_1).to receive(:heading).and_return(heading_1)
+    allow(note_2).to receive(:heading).and_return(heading_2)
+    allow(note_3).to receive(:heading).and_return(heading_3)
+  end
+
+  context "#child_notes" do
+    it 'is a sorted collection of Joplin::NoteFile objects' do
+      expect(note_links.child_notes).to eq([note_3, note_2, note_1])
+    end
+  end
+end

--- a/lib/spec/joplin/note_file_spec.rb
+++ b/lib/spec/joplin/note_file_spec.rb
@@ -109,6 +109,28 @@ RSpec.describe Joplin::NoteFile do
     end
   end
 
+  context "#has_heading?" do
+    before do
+      allow(note_file).to receive(:heading).and_return(heading)
+    end
+
+    context "when the heading has a value" do
+      let(:heading) { "heading" }
+
+      it 'is true' do
+        expect(note_file.has_heading?).to be_truthy
+      end
+    end
+
+    context "when the heading is blank" do
+      let(:heading) { "" }
+
+      it 'is false' do
+        expect(note_file.has_heading?).to be_falsey
+      end
+    end
+  end
+
   context "#basename" do
     it 'extracts the basename from the filename' do
       expect(note_file.basename).to eq(basename)

--- a/lib/spec/joplin/note_file_spec.rb
+++ b/lib/spec/joplin/note_file_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Joplin::NoteFile do
   let(:filename) { "foo/bar/#{basename}" }
-  let(:basename) { "#{id}#{Joplin::NoteFile::EXT_NAME}" }
+  let(:basename) { "#{id}#{Joplin::Base::EXT_NAME}" }
   let(:id) { "8775cd41e1d84ac2b631473f88fd8095" }
 
   subject(:note_file) { Joplin::NoteFile.new(filename) }

--- a/lib/spec/joplin/note_file_spec.rb
+++ b/lib/spec/joplin/note_file_spec.rb
@@ -173,4 +173,55 @@ RSpec.describe Joplin::NoteFile do
       expect(note_file.markdown_link).to eq(markdown_link)
     end
   end
+
+  context "comparisons" do
+    let(:note1) { Joplin::NoteFile.new("") }
+    let(:note2) { Joplin::NoteFile.new("") }
+
+    context "sort" do
+      before do
+        allow(note1).to receive(:heading).and_return("Zelta")
+        allow(note2).to receive(:heading).and_return("Alpha")
+      end
+
+      it 'uses the note heading' do
+        expect([note1, note2].sort).to eq([note2, note1])
+      end
+    end
+
+    context "equality" do
+      before do
+        allow(note1).to receive(:id).and_return(note1_id)
+        allow(note2).to receive(:id).and_return(note2_id)
+      end
+
+      context "for notes with the same ID" do
+        let(:note1_id) { "123" }
+        let(:note2_id) { "123" }
+
+        it 'is true' do
+          expect(note1 == note2).to eq(true)
+        end
+      end
+
+      context "for notes with different IDs" do
+        let(:note1_id) { "123" }
+        let(:note2_id) { "234" }
+
+        it 'is false' do
+          expect(note1 == note2).to eq(false)
+        end
+      end
+    end
+
+    context "uniqueness" do
+      before do
+        allow(note1).to receive(:id).and_return("123")
+      end
+
+      it 'removes duplicates with the same ID' do
+        expect([note1, note1, note1].uniq).to eq([note1])
+      end
+    end
+  end
 end

--- a/lib/spec/joplin/note_file_spec.rb
+++ b/lib/spec/joplin/note_file_spec.rb
@@ -174,6 +174,22 @@ RSpec.describe Joplin::NoteFile do
     end
   end
 
+  context "#child_notes" do
+    let(:note_contents) { double("note_contents") }
+    let(:note_links_component) { double(Joplin::NoteComponents::NoteLinks, child_notes: child_notes) }
+    let(:child_notes) { double("child_notes") }
+
+    before do
+      allow(note_file).to receive(:contents).and_return(note_contents)
+
+      allow(Joplin::NoteComponents::NoteLinks).to receive(:new).with(note_file.contents).and_return(note_links_component)
+    end
+
+    it 'is a collection of child notes provided by Joplin::NoteComponents::NoteLinks#child_notes' do
+      expect(note_file.child_notes).to eq(child_notes)
+    end
+  end
+
   context "comparisons" do
     let(:note1) { Joplin::NoteFile.new("") }
     let(:note2) { Joplin::NoteFile.new("") }

--- a/lib/spec/joplin/note_file_spec.rb
+++ b/lib/spec/joplin/note_file_spec.rb
@@ -87,8 +87,24 @@ RSpec.describe Joplin::NoteFile do
     end
 
     context "when the note file is not metadata or an attachment" do
-      it 'is true' do
-        expect(note_file).to be_is_note
+      before do
+        allow(note_file).to receive(:has_heading?).and_return(has_heading)
+      end
+
+      context "when it does not have a heading" do
+        let(:has_heading) { false }
+
+        it 'is false' do
+          expect(note_file).to_not be_is_note
+        end
+      end
+
+      context "when it has a heading" do
+        let(:has_heading) { true }
+
+        it 'is true' do
+          expect(note_file).to be_is_note
+        end
       end
     end
   end

--- a/lib/spec/joplin/table_of_contents/toc_processor_spec.rb
+++ b/lib/spec/joplin/table_of_contents/toc_processor_spec.rb
@@ -1,0 +1,69 @@
+RSpec.describe Joplin::TableOfContents::TocProcessor do
+  context "#process" do
+    context "when processing the top level note file" do
+      let(:note_file) { double(Joplin::NoteFile, markdown_link: markdown_link, child_notes: child_notes) }
+      let(:markdown_link) { "markdown_link" }
+      let(:child_notes) { [] }
+
+      subject(:toc_processor) { Joplin::TableOfContents::TocProcessor.new(note_file) }
+
+      it 'adds a link to the note file to the TOC' do
+        expect(toc_processor.process).to eq("* #{markdown_link}\n")
+      end
+
+      it 'adds the note file to the branch array' do
+        toc_processor.process
+
+        expect(toc_processor.branch).to include(note_file)
+      end
+
+      context "child note processing" do
+        let(:child_notes) { [child_note] }
+        let(:child_note) { double(Joplin::NoteFile) }
+        let(:nesting_level) { 1 }
+
+        before do
+          allow(Joplin::TableOfContents::TocProcessor).to receive(:new).with(
+            child_note,
+            level: nesting_level,
+            toc: toc_processor.toc,
+            branch: toc_processor.branch
+          ).and_return(child_note)
+        end
+
+        it 'processes the child notes with the nesting level incremented by one and the toc and branch objects' do
+          expect(child_note).to receive(:process)
+
+          toc_processor.process
+        end
+
+        context "for child notes that have already been processed in the current branch" do
+          before do
+            toc_processor.branch << child_note
+          end
+
+          it 'excludes any notes already processed in the current branch' do
+            expect(child_note).to_not receive(:process)
+
+            toc_processor.process
+          end
+        end
+
+        context "when the nesting level is over #{Joplin::TableOfContents::TocProcessor::NESTING_LIMIT}" do
+          let(:nesting_level) { Joplin::TableOfContents::TocProcessor::NESTING_LIMIT + 1 }
+          let(:child_markdown_link) { "child_markdown_link" }
+
+          before do
+            allow(child_note).to receive(:markdown_link).and_return(child_markdown_link)
+          end
+
+          subject(:toc_processor) { Joplin::TableOfContents::TocProcessor.new(note_file, level: nesting_level) }
+
+          it 'adds an indented skipped notes line to the TOC' do
+            expect(toc_processor.process).to include("    * _Skipped 1 child notes_")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/spec/joplin/table_of_contents_spec.rb
+++ b/lib/spec/joplin/table_of_contents_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe Joplin::TableOfContents do
+  let(:filename) { "#{id}#{Joplin::Base::EXT_NAME}" }
+  let(:id) { "051c175223fc4987bbc8b2bb22356037" }
+
+  context "find_note" do
+    let(:text_note_file) { Joplin::NoteFile.new(text_note_file_filename) }
+    let(:text_note_file_filename) { "text_note_file/#{filename}" }
+    let(:not_note_file) { Joplin::NoteFile.new(not_note_file_filename) }
+    let(:not_note_file_filename) { "not_note_file/#{filename}" }
+    let(:notes_dir) { "#{ENV["HOME"]}#{Alfred::Settings.base_directory}/*#{Joplin::Base::EXT_NAME}" }
+    let(:base_directory) { "/base_directory" }
+
+    before do
+      ENV["base_directory"] = base_directory
+
+      allow(text_note_file).to receive(:is_note?).and_return(true)
+      allow(not_note_file).to receive(:is_note?).and_return(false)
+
+      allow(Dir).to receive(:glob).
+        with(notes_dir).
+        and_yield(text_note_file_filename).
+        and_yield(not_note_file_filename)
+    end
+
+    it 'fetches the Joplin::NoteFile instance with the matching ID' do
+      allow(Joplin::NoteFile).to receive(:new).with(text_note_file_filename).and_return(text_note_file)
+      allow(Joplin::NoteFile).to receive(:new).with(not_note_file_filename).and_return(not_note_file)
+
+      expect(Joplin::TableOfContents.find_note(id)).to eq(text_note_file)
+    end
+
+    it 'has the same object_id (is the same Joplin::NoteFile instance) each time' do
+      allow_any_instance_of(Joplin::NoteFile).to receive(:is_note?).and_return(true)
+
+      expect(Joplin::TableOfContents.find_note(id).object_id).to eq(Joplin::TableOfContents.find_note(id).object_id)
+    end
+  end
+end


### PR DESCRIPTION
Alfred workflow to search for a specific note, generate a nested list containing a table of contents from its child notes and their descendants, then copy the Markdown bullet list to the system clipboard to be pasted into a page.

Could paste it back into the same page, but would need to remove it before attempting to update it again.